### PR TITLE
New way to add images or resources into CKEditor

### DIFF
--- a/app/assets/stylesheets/refinery/ckeditor.css.sass
+++ b/app/assets/stylesheets/refinery/ckeditor.css.sass
@@ -7,10 +7,7 @@
   width: 100%
 #page_part_body, #page_part_new_0
   textarea
-    +constant-width( 65% )
-#page_part_side_body, #page_part_new_1
-  textarea
-    +constant-width( 40% )
+    +constant-width( 99% )
 
 .ui-tabs-nav
   float: left
@@ -67,6 +64,34 @@
     display: block
     padding: 6px 6px 6px 26px
     background: transparent image_url('refinery/ckeditor/pdf.png') no-repeat 4px center
+.ckeditor-contextual
+  float: right
+  margin-top: -30px
+
+  a[class*=icon]
+    padding-left: 20px
+    background-repeat: no-repeat
+#ajax_modal
+  padding: 0 20px 50px 20px
+  #existing_image_size_area
+    margin: 10px
+    input
+      display: none
+
+  ul.ckeditor-select-attachments
+    li
+      display: inline-block
+      margin: 3px 5px
+      padding: 5px
+      border: 1px solid #eee
+      text-align: center
+      input
+        display: none
+      img
+        margin: auto
+        border: 2px solid #ccc
+      &.selected, #existing_image_size_area li.selected a
+        background-color: #22A7F2
 
 //
 

--- a/app/assets/stylesheets/refinery/ckeditor.css.sass
+++ b/app/assets/stylesheets/refinery/ckeditor.css.sass
@@ -85,6 +85,9 @@
       padding: 5px
       border: 1px solid #eee
       text-align: center
+      label
+        margin: 0
+        padding: 0
       input
         display: none
       img

--- a/app/controllers/refinery/ckeditor/admin/ckeditor_attachments_controller.rb
+++ b/app/controllers/refinery/ckeditor/admin/ckeditor_attachments_controller.rb
@@ -21,7 +21,7 @@ module Refinery
         def add_images
           if params[:ckeditor]
             @images = Refinery::Image.where(:id => params[:ckeditor][:image_ids])
-            @size = Refinery::Images.user_image_sizes[params[:ckeditor][:image_size].to_sym]
+            @size = Refinery::Images.user_image_sizes[params[:ckeditor][:image_size].to_sym] if params[:ckeditor][:enable_resize]
             @editor = params[:ckeditor][:editor]
           end
           respond_to do |format|

--- a/app/controllers/refinery/ckeditor/admin/ckeditor_attachments_controller.rb
+++ b/app/controllers/refinery/ckeditor/admin/ckeditor_attachments_controller.rb
@@ -4,8 +4,15 @@ module Refinery
       class CkeditorAttachmentsController < ::Refinery::AdminController
 
         def dialog_images
-          @images = Refinery::Image.paginate(:page => params[:page], :per_page => Image.per_page(true, true))
+          @images = Refinery::Image.paginate(:page => params[:page], :per_page => Refinery::Image.per_page(true, true))
 
+          respond_to do |format|
+            format.js
+          end
+        end
+
+        def dialog_resources
+          @resources = Refinery::Resource.paginate(:page => params[:page], :per_page => Refinery::Resource.per_page(true))
           respond_to do |format|
             format.js
           end
@@ -22,10 +29,20 @@ module Refinery
           end
         end
 
+        def add_resources
+          if params[:ckeditor]
+            @resources = Refinery::Resource.where(:id => params[:ckeditor][:resource_ids])
+            @editor = params[:ckeditor][:editor]
+          end
+          respond_to do |format|
+            format.js
+          end
+        end
+
         protected
 
         def restrict_controller
-          # super unless action_name == 'insert'
+          return true
         end
 
 

--- a/app/controllers/refinery/ckeditor/admin/ckeditor_attachments_controller.rb
+++ b/app/controllers/refinery/ckeditor/admin/ckeditor_attachments_controller.rb
@@ -1,0 +1,35 @@
+module Refinery
+  module Ckeditor
+    module Admin
+      class CkeditorAttachmentsController < ::Refinery::AdminController
+
+        def dialog_images
+          @images = Refinery::Image.paginate(:page => params[:page], :per_page => Image.per_page(true, true))
+
+          respond_to do |format|
+            format.js
+          end
+        end
+
+        def add_images
+          if params[:ckeditor]
+            @images = Refinery::Image.where(:id => params[:ckeditor][:image_ids])
+            @size = Refinery::Images.user_image_sizes[params[:ckeditor][:image_size].to_sym]
+            @editor = params[:ckeditor][:editor]
+          end
+          respond_to do |format|
+            format.js
+          end
+        end
+
+        protected
+
+        def restrict_controller
+          # super unless action_name == 'insert'
+        end
+
+
+      end
+    end
+  end
+end

--- a/app/views/refinery/admin/pages/_page_part_field.html.erb
+++ b/app/views/refinery/admin/pages/_page_part_field.html.erb
@@ -1,37 +1,8 @@
 <div class="page_part" id="<%= new_part ? "page_part_new_#{part_index}" : part.to_param %>">
+  <p class="ckeditor-contextual">
+    <%= link_to(t(:button_ckeditor_add_image, :scope => [:ckeditor]), ckeditor_admin_ckeditor_attachments_dialog_images_path(:for_editor => "page_parts_attributes_#{part_index}_body"), :remote => true, :class => 'add_icon', :title => t(:title_ckeditor_add_image, :scope => [:ckeditor])) %>
+  </p>
   <%= hidden_field_tag "page[parts_attributes][#{part_index}][title]", part.title if new_part %>
-  <%= text_area_tag "page[parts_attributes][#{part_index}][body]", part.body, :rows => 20, :class => "wysiwyg widest", :data => { :body_class => part.to_param } %>
+  <%= text_area_tag "page[parts_attributes][#{part_index}][body]", part.body, :rows => 40, :class => "wysiwyg widest", :data => { :body_class => part.to_param } %>
   <%= hidden_field_tag "page[parts_attributes][#{part_index}][position]", part_index if new_part %>
-
-  <div class="rightbar">
-    <ul>
-      <li><%= link_to "Images", "#images_container" %></li>
-      <li><%= link_to "Files", "#files_container" %></li>
-    </ul>
-
-    <div id="files_container">
-      <p>
-        <b>Drag and drop these files into the editor:</b>
-      </p>
-      <ul>
-        <% Refinery::Resource.all.each do |resource| %>
-          <li><%= link_to resource.title, resource.url %></li>
-        <% end %>
-      </ul>
-    </div>
-
-    <div id="images_container">
-      <p>
-        <b>Drag and drop these images into the editor:</b>
-      </p>
-      <ul>
-        <% Refinery::Image.all.each do |image| %>
-          <li>
-            <div class="box_of_holding"><%= image_tag image.url %></div>
-            <%= image.title %>
-          </li>
-        <% end %>
-      </ul>
-    </div>
-  </div>
 </div>

--- a/app/views/refinery/admin/pages/_page_part_field.html.erb
+++ b/app/views/refinery/admin/pages/_page_part_field.html.erb
@@ -1,6 +1,7 @@
 <div class="page_part" id="<%= new_part ? "page_part_new_#{part_index}" : part.to_param %>">
   <p class="ckeditor-contextual">
     <%= link_to(t(:button_ckeditor_add_image, :scope => [:ckeditor]), ckeditor_admin_ckeditor_attachments_dialog_images_path(:for_editor => "page_parts_attributes_#{part_index}_body"), :remote => true, :class => 'add_icon', :title => t(:title_ckeditor_add_image, :scope => [:ckeditor])) %>
+    <%= link_to(t(:button_ckeditor_add_resource, :scope => [:ckeditor]), ckeditor_admin_ckeditor_attachments_dialog_resources_path(:for_editor => "page_parts_attributes_#{part_index}_body"), :remote => true, :class => 'add_icon', :title => t(:title_ckeditor_add_resource, :scope => [:ckeditor])) %>
   </p>
   <%= hidden_field_tag "page[parts_attributes][#{part_index}][title]", part.title if new_part %>
   <%= text_area_tag "page[parts_attributes][#{part_index}][body]", part.body, :rows => 40, :class => "wysiwyg widest", :data => { :body_class => part.to_param } %>

--- a/app/views/refinery/ckeditor/admin/ckeditor_attachments/_images.html.erb
+++ b/app/views/refinery/ckeditor/admin/ckeditor_attachments/_images.html.erb
@@ -13,7 +13,11 @@
 <%= will_paginate(@images, :renderer => Refinery::CKEditor::WillPaginateRemoteLinkRenderer) %>
 
 <% unless @images.empty? %>
-    <div id="existing_image_size_area" class="clearfix">
+    <p>
+      <%= check_box_tag('ckeditor[enable_resize]', true, false, :onchange => "$('#existing_image_size_area').toggle()") %>
+      <%= label_tag(:ckeditor_enable_resize, t(:label_ckeditor_enable_resize, :scope => [:ckeditor]), :class => 'input_label') %>
+    </p>
+    <div id="existing_image_size_area" class="clearfix" style="display:none">
       <%= content_tag(:strong, t(:label_ckeditor_resize_image, :scope => [:ckeditor])) %>
       <ul>
         <%

--- a/app/views/refinery/ckeditor/admin/ckeditor_attachments/_images.html.erb
+++ b/app/views/refinery/ckeditor/admin/ckeditor_attachments/_images.html.erb
@@ -38,9 +38,4 @@
     </div>
   <% end %>
 
-<div class='form-actions form-actions-dialog'>
-  <div class='form-actions-left'>
-    <%= submit_tag(t(:button_text, :scope => [:refinery, :admin, :images, :existing_image]), :onclick => "$.post('#{ckeditor_admin_ckeditor_attachments_add_images_path}', $('#ajax_modal input').serialize())", :class => 'button') %>
-    <%= link_to(t(:cancel, :scope => [:refinery, :admin, :dialogs, :show]), "#close_dialog", :class => "close_dialog button", :onclick => 'close_dialog()') %>
-  </div>
-</div>
+<%= render(:partial => 'modal_form_actions', :locals => {:submit_path => ckeditor_admin_ckeditor_attachments_add_images_path}) %>

--- a/app/views/refinery/ckeditor/admin/ckeditor_attachments/_images.html.erb
+++ b/app/views/refinery/ckeditor/admin/ckeditor_attachments/_images.html.erb
@@ -1,0 +1,46 @@
+<%= hidden_field_tag('ckeditor[editor]', params[:for_editor]) %>
+<div class="clearfix">
+  <ul class="ckeditor-select-attachments">
+    <% @images.each do |image| %>
+      <li>
+        <%= check_box_tag('ckeditor[image_ids][]', image.id, false, :id => "ckeditor_image_id_#{image.id}", :onchange => "$(this).closest('li').toggleClass('selected');") %>
+        <%= label_tag("ckeditor_image_id_#{image.id}", image_fu(image, '150x150')) %>
+      </li>
+    <% end -%>
+  </ul>
+</div>
+
+<%= will_paginate(@images, :renderer => Refinery::CKEditor::WillPaginateRemoteLinkRenderer) %>
+
+<% unless @images.empty? %>
+    <div id="existing_image_size_area" class="clearfix">
+      <%= content_tag(:strong, t(:label_ckeditor_resize_image, :scope => [:ckeditor])) %>
+      <ul>
+        <%
+          Refinery::Images.user_image_sizes.sort_by { |key, geometry| geometry.to_i }.each_with_index do |(size, pixels), index|
+            safe_pixels = pixels.to_s.gsub(/[<>=]/, '')
+            # (parndt): ' selected' if size.to_s == 'medium' is not very generic, but I
+            # can't think of a decent way of making it so for even sets (e.g. 2,4,6,8,etc image sizes).
+        -%>
+            <li id="image_dialog_size_<%= index %>" class="image_dialog_size<%= ' selected' if size.to_s == 'medium' %>">
+              <%= radio_button_tag('ckeditor[image_size]', size, size.to_s == 'medium', :id => "ckeditor_image_size_#{size}", :onchange => "$(this).closest('ul').find('li').removeClass('selected');$(this).closest('li').toggleClass('selected');") %>
+              <label for="<%= "ckeditor_image_size_#{size}" %>">
+                <%= link_to(size.to_s, "##{size}",
+                                        :'data-geometry' => pixels,
+                                        :'data-size' => size.to_s.parameterize,
+                                        :title   => "#{size} image (#{safe_pixels})",
+                                        :tooltip => "#{size} image (#{safe_pixels})",
+                                        :onclick => "$(this).closest('li').find('input').attr('checked', true).change()") %>
+              </label>
+            </li>
+        <% end -%>
+      </ul>
+    </div>
+  <% end %>
+
+<div class='form-actions form-actions-dialog'>
+  <div class='form-actions-left'>
+    <%= submit_tag(t(:button_text, :scope => [:refinery, :admin, :images, :existing_image]), :onclick => "$.post('#{ckeditor_admin_ckeditor_attachments_add_images_path}', $('#ajax_modal input').serialize())", :class => 'button') %>
+    <%= link_to(t(:cancel, :scope => [:refinery, :admin, :dialogs, :show]), "#close_dialog", :class => "close_dialog button", :onclick => 'close_dialog()') %>
+  </div>
+</div>

--- a/app/views/refinery/ckeditor/admin/ckeditor_attachments/_modal_form_actions.html.erb
+++ b/app/views/refinery/ckeditor/admin/ckeditor_attachments/_modal_form_actions.html.erb
@@ -1,0 +1,6 @@
+<div class='form-actions form-actions-dialog'>
+  <div class='form-actions-left'>
+    <%= submit_tag(t(:button_text, :scope => [:refinery, :admin, :images, :existing_image]), :onclick => "$.post('#{submit_path}', $('#ajax_modal input').serialize())", :class => 'button') %>
+    <%= link_to(t(:cancel, :scope => [:refinery, :admin, :dialogs, :show]), "#close_dialog", :class => "close_dialog button", :onclick => 'close_dialog()') %>
+  </div>
+</div>

--- a/app/views/refinery/ckeditor/admin/ckeditor_attachments/_resources.html.erb
+++ b/app/views/refinery/ckeditor/admin/ckeditor_attachments/_resources.html.erb
@@ -1,0 +1,23 @@
+<%= hidden_field_tag('ckeditor[editor]', params[:for_editor]) %>
+
+<div class="clearfix">
+  <% group_by_date(@resources).each do |container|
+       date = Date.parse((resource_group = container.last).first.created_at.to_s) %>
+    <h3><%= l(date, :format => :long ) %></h3>
+    <ul id="ckeditor_" class="ckeditor-select-attachments">
+      <% resource_group.each do |resource| %>
+        <li class="clearfix record <%= cycle('on', 'on-hover') %>">
+          <%= check_box_tag('ckeditor[resource_ids][]', resource.id, false, :id => "ckeditor_resource_#{resource.id}", :onchange => "$(this).closest('li').toggleClass('selected');") %>
+          <label class="title <%= resource.ext.try(:downcase) %>" for="<%= "ckeditor_resource_#{resource.id}" %>">
+            <%= resource.title %><%= ".#{resource.ext}" if resource.ext %>
+            <span class="preview">- <%= number_to_human_size(resource.size) %></span>
+          </label>
+        </li>
+      <% end -%>
+    </ul>
+  <% end %>
+</div>
+
+<%= will_paginate(@resources, :renderer => Refinery::CKEditor::WillPaginateRemoteLinkRenderer) %>
+
+<%= render(:partial => 'modal_form_actions', :locals => {:submit_path => ckeditor_admin_ckeditor_attachments_add_resources_path}) %>

--- a/app/views/refinery/ckeditor/admin/ckeditor_attachments/add_images.js.erb
+++ b/app/views/refinery/ckeditor/admin/ckeditor_attachments/add_images.js.erb
@@ -1,0 +1,4 @@
+<% @images && @images.each do |image| %>
+  CKEDITOR.instances['<%= @editor %>'].insertHtml('<%=j image_fu(image, @size) %>');
+<% end %>
+close_dialog();

--- a/app/views/refinery/ckeditor/admin/ckeditor_attachments/add_resources.js.erb
+++ b/app/views/refinery/ckeditor/admin/ckeditor_attachments/add_resources.js.erb
@@ -1,0 +1,6 @@
+<% @resources && @resources.each do |resource| %>
+  CKEDITOR.instances['<%= @editor %>'].insertHtml('&nbsp;<%=j link_to(resource.file_name,
+                resource.url,
+                :title => t('.download', :size => number_to_human_size(resource.size))) %>&nbsp;');
+<% end %>
+close_dialog();

--- a/app/views/refinery/ckeditor/admin/ckeditor_attachments/dialog_images.js.erb
+++ b/app/views/refinery/ckeditor/admin/ckeditor_attachments/dialog_images.js.erb
@@ -1,0 +1,11 @@
+if (!$("#ajax_modal").is("*")) {
+  ajaxModal = $("<div />").attr({id: "ajax_modal", "class": "dialog"});
+} else {
+  ajaxModal = $("#ajax_modal");
+}
+
+
+ajaxModal.html("<%=j render(:partial => 'images') %>");
+<% if params[:page].nil? %>
+  ajaxModal.dialog({modal:true, width: "80%", title: "<%= t(:title_ckeditor_add_image, :scope => [:ckeditor]) %>"});
+<% end %>

--- a/app/views/refinery/ckeditor/admin/ckeditor_attachments/dialog_resources.js.erb
+++ b/app/views/refinery/ckeditor/admin/ckeditor_attachments/dialog_resources.js.erb
@@ -1,0 +1,11 @@
+if (!$("#ajax_modal").is("*")) {
+  ajaxModal = $("<div />").attr({id: "ajax_modal", "class": "dialog"});
+} else {
+  ajaxModal = $("#ajax_modal");
+}
+
+
+ajaxModal.html("<%=j render(:partial => 'resources') %>");
+<% if params[:page].nil? %>
+  ajaxModal.dialog({modal:true, width: "80%", title: "<%= t(:title_ckeditor_add_resource, :scope => [:ckeditor]) %>"});
+<% end %>

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -1,6 +1,7 @@
 cs:
   ckeditor:
     label_ckeditor_resize_image: 'Vybrat velikost'
+    label_ckeditor_enable_resize: 'Změnit velikost?'
     button_ckeditor_add_image: 'Přidat obrázek'
     button_ckeditor_add_resource: 'Přidat soubor'
     title_ckeditor_add_image: 'Vybrat obrázek'

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -1,0 +1,5 @@
+cs:
+  ckeditor:
+    label_ckeditor_resize_image: 'Vybrat velikost'
+    button_ckeditor_add_image: 'Přidat obrázek'
+    title_ckeditor_add_image: 'Vybrat obrázek'

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -2,4 +2,6 @@ cs:
   ckeditor:
     label_ckeditor_resize_image: 'Vybrat velikost'
     button_ckeditor_add_image: 'Přidat obrázek'
+    button_ckeditor_add_resource: 'Přidat soubor'
     title_ckeditor_add_image: 'Vybrat obrázek'
+    title_ckeditor_add_resource: 'Vybrat soubor'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,6 @@ en:
     label_ckeditor_resize_image: 'Select size'
     label_ckeditor_enable_resize: 'Resize ?'
     button_ckeditor_add_image: 'Add image'
-    button_ckeditor_add_resource: 'Přidat soubor'
+    button_ckeditor_add_resource: 'Add file'
     title_ckeditor_add_image: 'Choose image'
-    title_ckeditor_add_resource: 'Vybrat soubor'
+    title_ckeditor_add_resource: 'Choose file'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,5 @@
+en:
+  ckeditor:
+    label_ckeditor_resize_image: 'Select size'
+    button_ckeditor_add_image: 'Add image'
+    title_ckeditor_add_image: 'Choose image'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,7 @@
 en:
   ckeditor:
     label_ckeditor_resize_image: 'Select size'
+    label_ckeditor_enable_resize: 'Resize ?'
     button_ckeditor_add_image: 'Add image'
     button_ckeditor_add_resource: 'Přidat soubor'
     title_ckeditor_add_image: 'Choose image'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,4 +2,6 @@ en:
   ckeditor:
     label_ckeditor_resize_image: 'Select size'
     button_ckeditor_add_image: 'Add image'
+    button_ckeditor_add_resource: 'Přidat soubor'
     title_ckeditor_add_image: 'Choose image'
+    title_ckeditor_add_resource: 'Vybrat soubor'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,0 +1,8 @@
+fr:
+  ckeditor:
+    label_ckeditor_resize_image: 'Choisir la taille'
+    label_ckeditor_enable_resize: 'Redimensionner ?'
+    button_ckeditor_add_image: 'Ajouter une image'
+    button_ckeditor_add_resource: 'Ajouter un fichier'
+    title_ckeditor_add_image: 'Sélectionner une image'
+    title_ckeditor_add_resource: 'Sélectionner un fichier'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,12 @@
+Refinery::Core::Engine.routes.draw do
+
+  # Admin routes
+  namespace :ckeditor, :path => '' do
+    namespace :admin, :path => 'refinery' do
+      scope :path => 'ckeditor' do
+        get 'ckeditor_attachments/dialog_images', :to => 'ckeditor_attachments#dialog_images'
+        post 'ckeditor_attachments/add_images', :to => 'ckeditor_attachments#add_images'
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,9 @@ Refinery::Core::Engine.routes.draw do
       scope :path => 'ckeditor' do
         get 'ckeditor_attachments/dialog_images', :to => 'ckeditor_attachments#dialog_images'
         post 'ckeditor_attachments/add_images', :to => 'ckeditor_attachments#add_images'
+
+        get 'ckeditor_attachments/dialog_resources', :to => 'ckeditor_attachments#dialog_resources'
+        post 'ckeditor_attachments/add_resources', :to => 'ckeditor_attachments#add_resources'
       end
     end
   end

--- a/lib/refinery/ckeditor/will_paginate_remote_link_renderer.rb
+++ b/lib/refinery/ckeditor/will_paginate_remote_link_renderer.rb
@@ -1,0 +1,18 @@
+require "will_paginate/view_helpers/action_view"
+
+module Refinery
+  module CKEditor
+    class WillPaginateRemoteLinkRenderer < WillPaginate::ActionView::LinkRenderer
+      
+
+      private
+
+      def link(text, target, attributes = {})
+        attributes[:'data-remote'] = true
+        super(text, target, attributes)
+      end
+      
+      
+    end
+  end
+end

--- a/lib/refinerycms-ckeditor.rb
+++ b/lib/refinerycms-ckeditor.rb
@@ -1,4 +1,5 @@
 require "refinery/ckeditor/version"
+require "refinery/ckeditor/will_paginate_remote_link_renderer"
 
 module Refinery
   module CKEditor


### PR DESCRIPTION
I removed the current way to adding attachments to the editor. Above the CKEditor I added two buttons, first for images and second for resources. Both links display modal dialog,  allow select multiple items and pagination. Dialog for images allow to select size of selected images.
